### PR TITLE
Anchor to docs on mobile

### DIFF
--- a/scripts/zxc.js
+++ b/scripts/zxc.js
@@ -105,6 +105,8 @@ $(document).ready(function() {
         // Hide example for entries that don't have them.
         $('#current-doc #doc-example, #current-doc #doc-example-header').hide();
       }
+
+      $('#current-doc')[0].scrollIntoView();
     });
   };
 


### PR DESCRIPTION
Jumps to the docs for ease of use on mobile as not to requires excessive scrolling.